### PR TITLE
Set cordova-config to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "cli"
   ],
   "dependencies": {
-    "cordova-config": "0.5.0",
+    "cordova-config": "0.6.0",
     "meow": "^3.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The latest `cordova-config` (0.6.0) has 100% code coverage and some minor improvements.
